### PR TITLE
Add pages for chains

### DIFF
--- a/gatsby-browser.jsx
+++ b/gatsby-browser.jsx
@@ -1,0 +1,9 @@
+import React from "react";
+import { Web3Provider } from "./src/context/Web3Context";
+import { SearchProvider } from "./src/context/SearchContext";
+
+export const wrapRootElement = ({ element }) => (
+  <SearchProvider>
+    <Web3Provider>{element}</Web3Provider>
+  </SearchProvider>
+);

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -65,6 +65,8 @@ exports.sourceNodes = async ({
   }, Promise.resolve({}));
 
   chains
+    // Filter out non HTTP(S) RPC URLs
+    .map((chain) => ({ ...chain, rpc: chain.rpc.filter(rpc => rpc.startsWith('http://') || rpc.startsWith('https://'))}))
     .filter((chain) => chain.rpc.length > 0)
     .forEach((chain) => {
       const icon = chain.icon;

--- a/gatsby-ssr.jsx
+++ b/gatsby-ssr.jsx
@@ -1,0 +1,9 @@
+import React from "react";
+import { Web3Provider } from "./src/context/Web3Context";
+import { SearchProvider } from "./src/context/SearchContext";
+
+export const wrapRootElement = ({ element }) => (
+  <SearchProvider>
+    <Web3Provider>{element}</Web3Provider>
+  </SearchProvider>
+);

--- a/src/components/Chain.tsx
+++ b/src/components/Chain.tsx
@@ -12,6 +12,7 @@ import React, { useContext } from "react";
 import { Web3Context } from "../context/Web3Context";
 import { ChainData } from "../types/chain";
 import { ChainIcon } from "./ChainIcon";
+import { Link } from "gatsby";
 
 export const Chain = ({
   name,
@@ -26,51 +27,53 @@ export const Chain = ({
     handleAddChain({ name, chainId, nativeCurrency, ...rest });
   };
   return (
-    <Flex
-      flexDirection="column"
-      px="5"
-      py="4"
-      borderWidth="1px"
-      rounded="md"
-      boxShadow="base"
-    >
-      <Flex justifyContent="space-between">
-        <Flex flexDirection="column" minW="200px">
-          <Flex mb="2">
-            <Text
-              fontSize="lg"
-              fontWeight="semibold"
-              lineHeight="short"
-              isTruncated
-              verticalAlign="middle"
-            >
-              {name}
-            </Text>
+    <Link to={`/chain/${chainId}`}>
+      <Flex
+        flexDirection="column"
+        px="5"
+        py="4"
+        borderWidth="1px"
+        rounded="md"
+        boxShadow="base"
+      >
+        <Flex justifyContent="space-between">
+          <Flex flexDirection="column" minW="200px">
+            <Flex mb="2">
+              <Text
+                fontSize="lg"
+                fontWeight="semibold"
+                lineHeight="short"
+                isTruncated
+                verticalAlign="middle"
+              >
+                {name}
+              </Text>
+            </Flex>
+            <StatGroup mb="2">
+              <Stat>
+                <StatLabel>Chain ID</StatLabel>
+                <StatNumber fontSize="md">{chainId}</StatNumber>
+              </Stat>
+              <Stat>
+                <StatLabel>Currency</StatLabel>
+                <StatNumber fontSize="md">{nativeCurrency.symbol}</StatNumber>
+              </Stat>
+            </StatGroup>
           </Flex>
-          <StatGroup mb="2">
-            <Stat>
-              <StatLabel>Chain ID</StatLabel>
-              <StatNumber fontSize="md">{chainId}</StatNumber>
-            </Stat>
-            <Stat>
-              <StatLabel>Currency</StatLabel>
-              <StatNumber fontSize="md">{nativeCurrency.symbol}</StatNumber>
-            </Stat>
-          </StatGroup>
+          {icon && (
+            <Flex>
+              <ChainIcon name={name} icon={icon} />
+            </Flex>
+          )}
         </Flex>
-        {icon && (
-          <Flex>
-            <ChainIcon name={name} icon={icon} />
-          </Flex>
-        )}
+        <Center mt="auto">
+          {!isConnected ? (
+            <Button onClick={handleConnect}>Connect Wallet</Button>
+          ) : (
+            <Button onClick={handleAddChainClick}>Add Chain</Button>
+          )}
+        </Center>
       </Flex>
-      <Center mt="auto">
-        {!isConnected ? (
-          <Button onClick={handleConnect}>Connect Wallet</Button>
-        ) : (
-          <Button onClick={handleAddChainClick}>Add Chain</Button>
-        )}
-      </Center>
-    </Flex>
+    </Link>
   );
 };

--- a/src/components/Chain.tsx
+++ b/src/components/Chain.tsx
@@ -23,9 +23,17 @@ export const Chain = ({
 }: ChainData) => {
   const { isConnected, handleConnect, handleAddChain } =
     useContext(Web3Context);
-  const handleAddChainClick = () => {
+
+  const handleConnectClick = (event: React.MouseEvent) => {
+    event.preventDefault();
+    handleConnect();
+  };
+
+  const handleAddChainClick = (event: React.MouseEvent) => {
+    event.preventDefault();
     handleAddChain({ name, chainId, nativeCurrency, ...rest });
   };
+
   return (
     <Link to={`/chain/${chainId}`}>
       <Flex
@@ -68,7 +76,7 @@ export const Chain = ({
         </Flex>
         <Center mt="auto">
           {!isConnected ? (
-            <Button onClick={handleConnect}>Connect Wallet</Button>
+            <Button onClick={handleConnectClick}>Connect</Button>
           ) : (
             <Button onClick={handleAddChainClick}>Add Chain</Button>
           )}

--- a/src/components/ChainIcon.tsx
+++ b/src/components/ChainIcon.tsx
@@ -3,7 +3,7 @@ import { GatsbyImage } from "gatsby-plugin-image";
 import { ChainData } from "../types/chain";
 import { Image } from "@chakra-ui/react";
 
-export const ChainIcon = ({ icon, name }: Pick<ChainData, "icon" | "name">) =>
+export const ChainIcon = ({ icon, name, width = "40px" }: Pick<ChainData, "icon" | "name"> & { width?: string; }) =>
   icon.childImageSharp ? (
     <GatsbyImage
       objectFit="scale-down"
@@ -11,5 +11,5 @@ export const ChainIcon = ({ icon, name }: Pick<ChainData, "icon" | "name">) =>
       alt={name}
     />
   ) : (
-    <Image src={icon.publicURL} width="40px" />
+    <Image src={icon.publicURL} width={width} />
   );

--- a/src/components/ExternalLink.tsx
+++ b/src/components/ExternalLink.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+import { ExternalLinkIcon } from "@chakra-ui/icons";
+import { Link } from "@chakra-ui/react";
+
+export const ExternalLink = ({ href, children }) => (
+  <Link href={href} isExternal>
+    {children} <ExternalLinkIcon mx="2px" />
+  </Link>
+);

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -65,7 +65,7 @@ export const Header = ({ showSearch = true, showFilters = true }) => {
             size="lg"
             onClick={handleConnect}
           >
-            Connect Wallet
+            Connect
           </Button>
         ) : (
           <Button size="lg" w={{ base: "100%", md: "auto" }}>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -14,6 +14,7 @@ import { Search } from "./Search";
 import { FaGithub } from "react-icons/fa";
 import { AddIcon } from "@chakra-ui/icons";
 import { Filters } from "./Filters";
+import { Link as GatsbyLink } from "gatsby";
 
 export const Header = ({ showSearch = true, showFilters = true }) => {
   const { handleConnect, isConnected, address } = useContext(Web3Context);
@@ -33,7 +34,9 @@ export const Header = ({ showSearch = true, showFilters = true }) => {
       width="100%"
       zIndex="sticky"
     >
-      <Heading>Chainlist</Heading>
+      <GatsbyLink to="/">
+        <Heading as="h1">Chainlist</Heading>
+      </GatsbyLink>
       {showSearch && <Search />}
       <Flex>
         {showFilters && <Filters />}

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -5,7 +5,14 @@ import { Header } from "./Header";
 export const Layout = ({ children, headerProps = {} }) => (
   <Flex flexDirection="column" py="4" px="8" height="100vh" position="relative">
     <Header {...headerProps} />
-    <Flex as="main" flexDirection="column" mt={{ base: "164px", md: "16" }}>
+    <Flex
+      as="main"
+      flexDirection="column"
+      mt={{
+        base: headerProps.showSearch !== false ? "164px" : "116px",
+        md: "16",
+      }}
+    >
       {children}
     </Flex>
   </Flex>

--- a/src/components/RedFlagBadge.tsx
+++ b/src/components/RedFlagBadge.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { Badge, Tooltip } from "@chakra-ui/react";
+import { ChainData } from "../types/chain";
+
+export const RedFlagBadge = ({ redFlags }: Pick<ChainData, "redFlags">) => {
+  if (!redFlags || redFlags.length === 0) {
+    return null;
+  }
+  const flagLabel =
+    redFlags[0] === "reusedChainId"
+      ? "Flagged for reusing chain ID"
+      : "Flagged for unknown reasons";
+  return (
+    <Tooltip label={flagLabel}>
+      <Badge colorScheme="red" textTransform="capitalize">
+        Flagged
+      </Badge>
+    </Tooltip>
+  );
+};

--- a/src/components/RpcTable.tsx
+++ b/src/components/RpcTable.tsx
@@ -29,7 +29,7 @@ export const RpcTable = ({ rpcs, handleRpcClick }) => {
               <Td pl="0">{rpcUrl}</Td>
               <Td pr="0" textAlign="end">
                 {!isConnected ? (
-                  <Button onClick={handleConnect}>Connect Wallet</Button>
+                  <Button onClick={handleConnect}>Connect</Button>
                 ) : (
                   <Button onClick={() => handleRpcClick(rpcUrl)}>
                     Add Chain

--- a/src/components/RpcTable.tsx
+++ b/src/components/RpcTable.tsx
@@ -1,0 +1,45 @@
+import React, { useContext } from "react";
+import {
+  Button,
+  Table,
+  TableContainer,
+  Tbody,
+  Td,
+  Th,
+  Thead,
+  Tr,
+} from "@chakra-ui/react";
+import { Web3Context } from "../context/Web3Context";
+
+export const RpcTable = ({ rpcs, handleRpcClick }) => {
+  const { isConnected, handleConnect } = useContext(Web3Context);
+
+  return (
+    <TableContainer>
+      <Table>
+        <Thead>
+          <Tr>
+            <Th pl="0">RPC URL</Th>
+            <Th></Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {rpcs.map((rpcUrl) => (
+            <Tr>
+              <Td pl="0">{rpcUrl}</Td>
+              <Td pr="0" textAlign="end">
+                {!isConnected ? (
+                  <Button onClick={handleConnect}>Connect Wallet</Button>
+                ) : (
+                  <Button onClick={() => handleRpcClick(rpcUrl)}>
+                    Add Chain
+                  </Button>
+                )}
+              </Td>
+            </Tr>
+          ))}
+        </Tbody>
+      </Table>
+    </TableContainer>
+  );
+};

--- a/src/components/StatValue.tsx
+++ b/src/components/StatValue.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+import { VStack } from "@chakra-ui/react";
+
+export const StatValue = ({ children }: { children: React.ReactNode }) => (
+  <VStack align="start" gap="1">
+    {children}
+  </VStack>
+);

--- a/src/components/StatusBadge.tsx
+++ b/src/components/StatusBadge.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import { Badge } from "@chakra-ui/react";
+import { ChainData } from "../types/chain";
+
+export const StatusBadge = ({ status }: Pick<ChainData, "status">) => {
+  const actualStatus = status ?? "Active";
+  const colorScheme = status === "deprecated" ? "yellow" : undefined;
+  return (
+    <Badge textTransform="capitalize" colorScheme={colorScheme}>
+      {actualStatus}
+    </Badge>
+  );
+};

--- a/src/pages/chain/{Chain.chainId}.tsx
+++ b/src/pages/chain/{Chain.chainId}.tsx
@@ -1,0 +1,120 @@
+import React, { useContext } from "react";
+import {
+  Box,
+  Button,
+  Flex,
+  StatGroup,
+  StatLabel,
+  Stat,
+  StatNumber,
+  Heading,
+  Text,
+} from "@chakra-ui/react";
+import { graphql } from "gatsby";
+import { Seo } from "../../components/SEO";
+import { SearchProvider } from "../../context/SearchContext";
+import { Web3Context, Web3Provider } from "../../context/Web3Context";
+import { Header } from "../../components/Header";
+import { ChainIcon } from "../../components/ChainIcon";
+import { Layout } from "../../components/Layout";
+
+const ChainPage = ({ data }) => {
+  const { name, chainId, nativeCurrency, icon, explorers, rpc, slip44 } =
+    data.chain;
+
+  const { isConnected, handleConnect, handleAddChain } =
+    useContext(Web3Context);
+  const handleAddChainClick = () => {
+    handleAddChain({ name, chainId, nativeCurrency, ...rest });
+  };
+
+  return (
+    <>
+      <Seo />
+      <Web3Provider>
+        <SearchProvider>
+          <Layout headerProps={{ showSearch: false, showFilters: false }}>
+            <Flex flexDirection="column">
+              <Flex justifyContent="space-between" alignItems="center" mb="2">
+                <Flex alignItems="center">
+                  {icon && (
+                    <Flex mr="2">
+                      <ChainIcon name={name} icon={icon} />
+                    </Flex>
+                  )}
+                  <Heading as="h3" size="lg">
+                    {name}
+                  </Heading>
+                </Flex>
+                {!isConnected ? (
+                  <Button onClick={handleConnect}>Connect Wallet</Button>
+                ) : (
+                  <Button onClick={handleAddChainClick}>Add Chain</Button>
+                )}
+              </Flex>
+              <StatGroup>
+                <Stat>
+                  <StatLabel>Chain ID</StatLabel>
+                  <StatNumber fontSize="md">{chainId}</StatNumber>
+                </Stat>
+                <Stat>
+                  <StatLabel>Currency</StatLabel>
+                  <StatNumber fontSize="md">{nativeCurrency.symbol}</StatNumber>
+                </Stat>
+                <Stat>
+                  <StatLabel>SLIP44</StatLabel>
+                  <StatNumber fontSize="md">{slip44}</StatNumber>
+                </Stat>
+              </StatGroup>
+              <Text fontWeight="semibold" mt="2">
+                RPC URLs
+              </Text>
+              {rpc.map((rpcUrl) => (
+                <Text>{rpcUrl}</Text>
+              ))}
+              <Text fontWeight="semibold" mt="2">
+                Explorers
+              </Text>
+              {explorers.map((explorer) => (
+                <Text>{explorer.url}</Text>
+              ))}
+            </Flex>
+          </Layout>
+        </SearchProvider>
+      </Web3Provider>
+    </>
+  );
+};
+
+export const query = graphql`
+  query ($id: String) {
+    chain(id: { eq: $id }) {
+      id
+      name
+      chain
+      chainId
+      rpc
+      icon {
+        publicURL
+        childImageSharp {
+          gatsbyImageData(width: 40, placeholder: NONE)
+        }
+      }
+      nativeCurrency {
+        decimals
+        name
+        symbol
+      }
+      explorers {
+        url
+        name
+        standard
+      }
+      status
+      faucets
+      slip44
+    }
+  }
+`;
+
+export default ChainPage;

--- a/src/pages/chain/{Chain.chainId}.tsx
+++ b/src/pages/chain/{Chain.chainId}.tsx
@@ -47,68 +47,64 @@ const ChainPage = ({ data }) => {
   return (
     <>
       <Seo />
-      <Web3Provider>
-        <SearchProvider>
-          <Layout headerProps={{ showSearch: false, showFilters: false }}>
-            <Flex flexDirection="column" mt="8">
-              <Flex justifyContent="space-between" alignItems="center">
-                <Flex alignItems="center">
-                  {icon && (
-                    <Flex mr="6">
-                      <ChainIcon name={name} icon={icon} width="60px" />
-                    </Flex>
-                  )}
-                  <Heading size="2xl">{name}</Heading>
+      <Layout headerProps={{ showSearch: false, showFilters: false }}>
+        <Flex flexDirection="column" mt="8">
+          <Flex justifyContent="space-between" alignItems="center">
+            <Flex alignItems="center">
+              {icon && (
+                <Flex mr="6">
+                  <ChainIcon name={name} icon={icon} width="60px" />
                 </Flex>
-                {!isConnected ? (
-                  <Button onClick={handleConnect}>Connect Wallet</Button>
-                ) : (
-                  <Button onClick={handleAddChainClick}>Add Chain</Button>
-                )}
-              </Flex>
-              <Divider my="8" />
-              <StatGroup>
-                <Stat>
-                  <StatLabel>Chain ID</StatLabel>
-                  <StatNumber fontSize="md">{chainId}</StatNumber>
-                </Stat>
-                <Stat>
-                  <StatLabel>Currency</StatLabel>
-                  <StatNumber fontSize="md">{nativeCurrency.symbol}</StatNumber>
-                </Stat>
-                <Stat>
-                  <StatLabel>Status</StatLabel>
-                  <StatNumber fontSize="md" textTransform="capitalize">
-                    {status ?? "Active"}
-                  </StatNumber>
-                </Stat>
-                {infoURL && (
-                  <Stat>
-                    <StatLabel>Info</StatLabel>
-                    <StatNumber fontSize="md">
-                      <ExternalLink href={infoURL}>{infoURL}</ExternalLink>
-                    </StatNumber>
-                  </Stat>
-                )}
-                {explorers && (
-                  <Stat>
-                    <StatLabel>Explorers</StatLabel>
-                    <StatNumber fontSize="md">
-                      {explorers.map((explorer) => (
-                        <ExternalLink href={explorer.url}>
-                          {explorer.url}
-                        </ExternalLink>
-                      ))}
-                    </StatNumber>
-                  </Stat>
-                )}
-              </StatGroup>
-              <Divider my="8" />
-              <RpcTable rpcs={rpc} handleRpcClick={handleRpcClick} />
+              )}
+              <Heading size="2xl">{name}</Heading>
             </Flex>
-          </Layout>
-        </SearchProvider>
-      </Web3Provider>
+            {!isConnected ? (
+              <Button onClick={handleConnect}>Connect Wallet</Button>
+            ) : (
+              <Button onClick={handleAddChainClick}>Add Chain</Button>
+            )}
+          </Flex>
+          <Divider my="8" />
+          <StatGroup>
+            <Stat>
+              <StatLabel>Chain ID</StatLabel>
+              <StatNumber fontSize="md">{chainId}</StatNumber>
+            </Stat>
+            <Stat>
+              <StatLabel>Currency</StatLabel>
+              <StatNumber fontSize="md">{nativeCurrency.symbol}</StatNumber>
+            </Stat>
+            <Stat>
+              <StatLabel>Status</StatLabel>
+              <StatNumber fontSize="md" textTransform="capitalize">
+                {status ?? "Active"}
+              </StatNumber>
+            </Stat>
+            {infoURL && (
+              <Stat>
+                <StatLabel>Info</StatLabel>
+                <StatNumber fontSize="md">
+                  <ExternalLink href={infoURL}>{infoURL}</ExternalLink>
+                </StatNumber>
+              </Stat>
+            )}
+            {explorers && (
+              <Stat>
+                <StatLabel>Explorers</StatLabel>
+                <StatNumber fontSize="md">
+                  {explorers.map((explorer) => (
+                    <ExternalLink href={explorer.url}>
+                      {explorer.url}
+                    </ExternalLink>
+                  ))}
+                </StatNumber>
+              </Stat>
+            )}
+          </StatGroup>
+          <Divider my="8" />
+          <RpcTable rpcs={rpc} handleRpcClick={handleRpcClick} />
+        </Flex>
+      </Layout>
     </>
   );
 };

--- a/src/pages/chain/{Chain.chainId}.tsx
+++ b/src/pages/chain/{Chain.chainId}.tsx
@@ -1,26 +1,27 @@
 import React, { useContext } from "react";
 import {
-  Box,
   Button,
   Flex,
   StatGroup,
   StatLabel,
   Stat,
-  StatNumber,
   Heading,
-  Text,
   Divider,
+  Text,
 } from "@chakra-ui/react";
 import { graphql } from "gatsby";
 import { Seo } from "../../components/SEO";
-import { SearchProvider } from "../../context/SearchContext";
-import { Web3Context, Web3Provider } from "../../context/Web3Context";
+import { Web3Context } from "../../context/Web3Context";
 import { ChainIcon } from "../../components/ChainIcon";
 import { Layout } from "../../components/Layout";
 import { ExternalLink } from "../../components/ExternalLink";
 import { RpcTable } from "../../components/RpcTable";
+import { RedFlagBadge } from "../../components/RedFlagBadge";
+import { StatusBadge } from "../../components/StatusBadge";
+import { StatValue } from "../../components/StatValue";
+import { ChainData } from "../../types/chain";
 
-const ChainPage = ({ data }) => {
+const ChainPage = ({ data }: { data: { chain: ChainData } }) => {
   const {
     name,
     chainId,
@@ -28,7 +29,7 @@ const ChainPage = ({ data }) => {
     icon,
     explorers,
     rpc,
-    slip44,
+    redFlags,
     infoURL,
     status,
   } = data.chain;
@@ -40,7 +41,7 @@ const ChainPage = ({ data }) => {
     handleAddChain({ name, chainId, nativeCurrency, rpc, explorers });
   };
 
-  const handleRpcClick = (rpc) => {
+  const handleRpcClick = (rpc: string) => {
     handleAddChain({ name, chainId, nativeCurrency, rpc: [rpc], explorers });
   };
 
@@ -65,39 +66,44 @@ const ChainPage = ({ data }) => {
             )}
           </Flex>
           <Divider my="8" />
-          <StatGroup>
+          <StatGroup flexDirection={["column", null, "row"]} gap={[2, null, 0]}>
             <Stat>
               <StatLabel>Chain ID</StatLabel>
-              <StatNumber fontSize="md">{chainId}</StatNumber>
+              <StatValue>
+                <Text>{chainId}</Text>
+              </StatValue>
             </Stat>
             <Stat>
               <StatLabel>Currency</StatLabel>
-              <StatNumber fontSize="md">{nativeCurrency.symbol}</StatNumber>
+              <StatValue>
+                <Text>{nativeCurrency.symbol}</Text>
+              </StatValue>
             </Stat>
             <Stat>
-              <StatLabel>Status</StatLabel>
-              <StatNumber fontSize="md" textTransform="capitalize">
-                {status ?? "Active"}
-              </StatNumber>
+              <StatLabel mb="1.5">Status</StatLabel>
+              <StatValue>
+                <StatusBadge status={status} />
+                <RedFlagBadge redFlags={redFlags} />
+              </StatValue>
             </Stat>
             {infoURL && (
               <Stat>
                 <StatLabel>Info</StatLabel>
-                <StatNumber fontSize="md">
+                <StatValue>
                   <ExternalLink href={infoURL}>{infoURL}</ExternalLink>
-                </StatNumber>
+                </StatValue>
               </Stat>
             )}
             {explorers && (
               <Stat>
                 <StatLabel>Explorers</StatLabel>
-                <StatNumber fontSize="md">
+                <StatValue>
                   {explorers.map((explorer) => (
                     <ExternalLink href={explorer.url}>
                       {explorer.url}
                     </ExternalLink>
                   ))}
-                </StatNumber>
+                </StatValue>
               </Stat>
             )}
           </StatGroup>
@@ -135,7 +141,7 @@ export const query = graphql`
       }
       status
       faucets
-      slip44
+      redFlags
       infoURL
     }
   }

--- a/src/pages/chain/{Chain.chainId}.tsx
+++ b/src/pages/chain/{Chain.chainId}.tsx
@@ -9,23 +9,39 @@ import {
   StatNumber,
   Heading,
   Text,
+  Divider,
 } from "@chakra-ui/react";
 import { graphql } from "gatsby";
 import { Seo } from "../../components/SEO";
 import { SearchProvider } from "../../context/SearchContext";
 import { Web3Context, Web3Provider } from "../../context/Web3Context";
-import { Header } from "../../components/Header";
 import { ChainIcon } from "../../components/ChainIcon";
 import { Layout } from "../../components/Layout";
+import { ExternalLink } from "../../components/ExternalLink";
+import { RpcTable } from "../../components/RpcTable";
 
 const ChainPage = ({ data }) => {
-  const { name, chainId, nativeCurrency, icon, explorers, rpc, slip44 } =
-    data.chain;
+  const {
+    name,
+    chainId,
+    nativeCurrency,
+    icon,
+    explorers,
+    rpc,
+    slip44,
+    infoURL,
+    status,
+  } = data.chain;
 
   const { isConnected, handleConnect, handleAddChain } =
     useContext(Web3Context);
+
   const handleAddChainClick = () => {
-    handleAddChain({ name, chainId, nativeCurrency, ...rest });
+    handleAddChain({ name, chainId, nativeCurrency, rpc, explorers });
+  };
+
+  const handleRpcClick = (rpc) => {
+    handleAddChain({ name, chainId, nativeCurrency, rpc: [rpc], explorers });
   };
 
   return (
@@ -34,17 +50,15 @@ const ChainPage = ({ data }) => {
       <Web3Provider>
         <SearchProvider>
           <Layout headerProps={{ showSearch: false, showFilters: false }}>
-            <Flex flexDirection="column">
-              <Flex justifyContent="space-between" alignItems="center" mb="2">
+            <Flex flexDirection="column" mt="8">
+              <Flex justifyContent="space-between" alignItems="center">
                 <Flex alignItems="center">
                   {icon && (
-                    <Flex mr="2">
-                      <ChainIcon name={name} icon={icon} />
+                    <Flex mr="6">
+                      <ChainIcon name={name} icon={icon} width="60px" />
                     </Flex>
                   )}
-                  <Heading as="h3" size="lg">
-                    {name}
-                  </Heading>
+                  <Heading size="2xl">{name}</Heading>
                 </Flex>
                 {!isConnected ? (
                   <Button onClick={handleConnect}>Connect Wallet</Button>
@@ -52,6 +66,7 @@ const ChainPage = ({ data }) => {
                   <Button onClick={handleAddChainClick}>Add Chain</Button>
                 )}
               </Flex>
+              <Divider my="8" />
               <StatGroup>
                 <Stat>
                   <StatLabel>Chain ID</StatLabel>
@@ -62,22 +77,34 @@ const ChainPage = ({ data }) => {
                   <StatNumber fontSize="md">{nativeCurrency.symbol}</StatNumber>
                 </Stat>
                 <Stat>
-                  <StatLabel>SLIP44</StatLabel>
-                  <StatNumber fontSize="md">{slip44}</StatNumber>
+                  <StatLabel>Status</StatLabel>
+                  <StatNumber fontSize="md" textTransform="capitalize">
+                    {status ?? "Active"}
+                  </StatNumber>
                 </Stat>
+                {infoURL && (
+                  <Stat>
+                    <StatLabel>Info</StatLabel>
+                    <StatNumber fontSize="md">
+                      <ExternalLink href={infoURL}>{infoURL}</ExternalLink>
+                    </StatNumber>
+                  </Stat>
+                )}
+                {explorers && (
+                  <Stat>
+                    <StatLabel>Explorers</StatLabel>
+                    <StatNumber fontSize="md">
+                      {explorers.map((explorer) => (
+                        <ExternalLink href={explorer.url}>
+                          {explorer.url}
+                        </ExternalLink>
+                      ))}
+                    </StatNumber>
+                  </Stat>
+                )}
               </StatGroup>
-              <Text fontWeight="semibold" mt="2">
-                RPC URLs
-              </Text>
-              {rpc.map((rpcUrl) => (
-                <Text>{rpcUrl}</Text>
-              ))}
-              <Text fontWeight="semibold" mt="2">
-                Explorers
-              </Text>
-              {explorers.map((explorer) => (
-                <Text>{explorer.url}</Text>
-              ))}
+              <Divider my="8" />
+              <RpcTable rpcs={rpc} handleRpcClick={handleRpcClick} />
             </Flex>
           </Layout>
         </SearchProvider>
@@ -97,7 +124,7 @@ export const query = graphql`
       icon {
         publicURL
         childImageSharp {
-          gatsbyImageData(width: 40, placeholder: NONE)
+          gatsbyImageData(width: 60, placeholder: NONE)
         }
       }
       nativeCurrency {
@@ -113,6 +140,7 @@ export const query = graphql`
       status
       faucets
       slip44
+      infoURL
     }
   }
 `;

--- a/src/pages/chain/{Chain.chainId}.tsx
+++ b/src/pages/chain/{Chain.chainId}.tsx
@@ -49,18 +49,27 @@ const ChainPage = ({ data }: { data: { chain: ChainData } }) => {
     <>
       <Seo />
       <Layout headerProps={{ showSearch: false, showFilters: false }}>
-        <Flex flexDirection="column" mt="8">
-          <Flex justifyContent="space-between" alignItems="center">
-            <Flex alignItems="center">
+        <Flex flexDirection="column" mt={["0", null, "8"]}>
+          <Flex
+            flexDirection={["column", null, "row"]}
+            justifyContent="space-between"
+            alignItems="center"
+            gap="6"
+          >
+            <Flex
+              flexDirection={["column", null, "row"]}
+              alignItems="center"
+              gap="6"
+            >
               {icon && (
-                <Flex mr="6">
+                <Flex>
                   <ChainIcon name={name} icon={icon} width="60px" />
                 </Flex>
               )}
               <Heading size="2xl">{name}</Heading>
             </Flex>
             {!isConnected ? (
-              <Button onClick={handleConnect}>Connect Wallet</Button>
+              <Button onClick={handleConnect}>Connect</Button>
             ) : (
               <Button onClick={handleAddChainClick}>Add Chain</Button>
             )}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,21 +1,14 @@
-import { graphql, useStaticQuery } from "gatsby";
 import React from "react";
 import { ChainList } from "../components/ChainList";
 import { Seo } from "../components/SEO";
-import { Web3Provider } from "../context/Web3Context";
-import { SearchProvider } from "../context/SearchContext";
 import { Layout } from "../components/Layout";
 
 const IndexPage = () => (
   <>
     <Seo />
-    <Web3Provider>
-      <SearchProvider>
-        <Layout>
-          <ChainList />
-        </Layout>
-      </SearchProvider>
-    </Web3Provider>
+    <Layout>
+      <ChainList />
+    </Layout>
   </>
 );
 

--- a/src/types/chain.ts
+++ b/src/types/chain.ts
@@ -11,6 +11,9 @@ export interface ChainData {
   chainId: number;
   nativeCurrency: ChainCurrency;
   explorers?: BlockExplorer[];
+  status?: string;
+  redFlags?: string[];
+  infoURL?: string;
 }
 
 export interface ChainCurrency {


### PR DESCRIPTION
Adds a details page for each chain that can be accessed by clicking the cards on the front page.

This page allows you to connect to additional RPCs for each chain as well as exposes some more information about the the chain to the user.