### PR TITLE
fix: Discard invalid images

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "gatsby-plugin-sharp": "^5.10.0",
     "gatsby-transformer-sharp": "^5.10.0",
     "node-fetch": "^2.6.11",
+    "probe-image-size": "^7.2.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-helmet": "^6.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6648,6 +6648,7 @@ __metadata:
     gatsby-transformer-json: ^5.10.0
     gatsby-transformer-sharp: ^5.10.0
     node-fetch: ^2.6.11
+    probe-image-size: ^7.2.3
     react: ^18.2.0
     react-dom: ^18.2.0
     react-helmet: ^6.1.0


### PR DESCRIPTION
Discard invalid images to prevent issues later in the build process crashing when trying to use `probe-image-size`